### PR TITLE
Change -1 argument to None, change import name to avoid warning

### DIFF
--- a/Rigol1000z/rigol1000z.py
+++ b/Rigol1000z/rigol1000z.py
@@ -1,7 +1,7 @@
 import os
 import numpy as _np
 import tqdm as _tqdm
-import visa as _visa
+import pyvisa as _visa
 
 class _Rigol1000zChannel:
     '''
@@ -273,13 +273,13 @@ class Rigol1000z:
     def visa_read(self):
         return self.visa_resource.read().strip()
 
-    def visa_read_raw(self, num_bytes=-1):
+    def visa_read_raw(self, num_bytes=None):
         return self.visa_resource.read_raw(num_bytes)
 
     def visa_ask(self, cmd):
         return self.visa_resource.query(cmd)
 
-    def visa_ask_raw(self, cmd, num_bytes=-1):
+    def visa_ask_raw(self, cmd, num_bytes=None):
         self.visa_write(cmd)
         return self.visa_read_raw(num_bytes)
 
@@ -347,7 +347,7 @@ class Rigol1000z:
 
     def set_memory_depth(self, pts):
         num_enabled_chans = sum(self.get_channels_enabled())
-        
+
         pts = int(pts) if pts != 'AUTO' else pts
 
         if num_enabled_chans == 1:
@@ -359,7 +359,7 @@ class Rigol1000z:
 
         self.run()
         self.visa_write(':acq:mdep %s' % pts)
-        
+
     def get_channels_enabled(self):
         return [c.enabled() for c in self._channels]
 


### PR DESCRIPTION
When calling the `read_raw` argument of the visa resource, the default argument of -1 yields the following error:
`ValueError: Array length must be >= 0, not -1`

Changing the argument to 'None' removes this error. 

This argument is ultimately passed to the `_read_raw` function in pyvisa, for which the default argument is `None`. [Source](https://github.com/pyvisa/pyvisa/blob/main/pyvisa/resources/messagebased.py#L407-L453)
